### PR TITLE
Update convertToPA.R

### DIFF
--- a/R/convertToPA.R
+++ b/R/convertToPA.R
@@ -158,7 +158,7 @@ convertToPA <- function(x,
       sp.raster <- x$suitab.raster
     } else stop("x must be:\n- a raster layer object\nor\n- the output list from functions
                generateSpFromFun(), generateSpFromPCA() or generateRandomSp()")
-  } else if (is.raster(x))
+  } else if (class(x) == "RasterLayer")
   {
     sp.raster <- x
   } else stop("x must be:\n- a raster layer object\nor\n- the output list from functions
@@ -539,7 +539,7 @@ convertToPA <- function(x,
     x$pa.raster = PA.raster
     results <- x
     if(plot) plot(stack(results$suitab.raster, results$pa.raster), main = c("Suitability", "Presence-absence"))
-  } else if (is.raster(x))
+  } else if (class(x) == "RasterLayer")
   {
     if(PA.method == "threshold")
     {


### PR DESCRIPTION
Using is.raster on RasterLayer objects returns FALSE, which was causing convertToPA to fail when used on RasterLayer objects.
