### PR TITLE
Fixed bug in sampleOccurrences when specifying sample.prevalence argument

### DIFF
--- a/R/sampleOccurrences.R
+++ b/R/sampleOccurrences.R
@@ -447,8 +447,8 @@ sampleOccurrences <- function(x, n,
       {
         sample.points <- dismo::randomPoints(sample.raster * bias.raster, n = n, prob = TRUE, tryf = 1)
       } else
-      {
-        tmp1 <- sample.points
+      { 
+        tmp1 <- sample.raster
         tmp1[sp.raster != 1] <- NA
         sample.points <- dismo::randomPoints(tmp1 * bias.raster, n = sample.prevalence * n, prob = TRUE, tryf = 1)
         tmp1 <- sample.raster


### PR DESCRIPTION
Fixed small bug that was causing an error when trying to specify 'sample.prevalence' with a sampling bias in function sampleOccurrences(). 