### PR TITLE
Minor fix to @Farewe's adjustments

### DIFF
--- a/R/generateRandomSp.R
+++ b/R/generateRandomSp.R
@@ -294,7 +294,7 @@ generateRandomSp <- function(raster.stack,
   if(convert.to.PA == TRUE) {
     message(" - Converting into Presence - Absence\n")
     
-    # Need to rescale suitability to be between 0 and 1 if rescale = FALSE
+    # Need to adjust alpha to appropriate scale if rescale = FALSE
     if(rescale == FALSE) {
       if(adjust.alpha)
       {
@@ -308,10 +308,8 @@ generateRandomSp <- function(raster.stack,
                              species.prevalence = species.prevalence,
                              plot = FALSE)
     
-      if(plot) plot(stack(results$raw.suitab.raster, 
-                          results$suitab.raster, 
-                          results$pa.raster), main = c("Raw suitability", 
-                                                       "Suitability", 
+      if(plot) plot(stack(results$suitab.raster, 
+                          results$pa.raster), main = c("Suitability", 
                                                        "Presence-absence"))
     } else {
       


### PR DESCRIPTION
@Farewe, I've modified the code to remove residual references to raw.suitab.raster to avoid the following issue:


```
x <- virtualspecies::generateRandomSp(ras_stack,
                  approach = "automatic",
                  PA.method ="probability", 
                  rescale = FALSE,
                  rescale.each.response = TRUE,convert.to.PA = TRUE)
 - Determining species' response to predictor variables

 - Calculating species suitability

 - Converting into Presence - Absence

   --- Determing species.prevalence automatically according to alpha and beta


Error in stack.default(results$raw.suitab.raster, results$suitab.raster,  : 
  at least one vector element is required
```