### PR TITLE
Fix a raster name bug in function generateSpFromFun

### DIFF
--- a/R/generateSpFromFun.R
+++ b/R/generateSpFromFun.R
@@ -225,7 +225,7 @@ generateSpFromFun <- function(raster.stack, parameters,
     }
     )
   }))
-  names(suitab.raster) <- names(parameters)
+  names(suitab.raster) <- names(raster.stack)
   
   for (var in names(raster.stack))
   {


### PR DESCRIPTION
The `generateSpFromFun` function renames the processed `suitab.raster` using the names from `parameters` in line 228. However, this approach only works if the names are in the exact same order. A more reliable method is to rename `suitab.raster` using the names from the original `raster.stack`.